### PR TITLE
create-basic-data-models

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,61 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: true
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: true
+:exclude_sti_subclasses: false
+:exclude_tests: true
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:timestamp_columns:
+- created_at
+- updated_at
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "mission_control-jobs"
 gem "motor-admin"
 
 group :development, :test do
+  gem "annotaterb"
   gem "dotenv"
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    annotaterb (4.15.0)
     ar_lazy_preload (1.1.2)
       rails (>= 5.2)
     ast (2.4.3)
@@ -398,6 +399,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  annotaterb
   bcrypt (~> 3.1.7)
   bootsnap
   capybara

--- a/app/models/backup_log.rb
+++ b/app/models/backup_log.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: backup_logs
+#
+#  id                :integer          not null, primary key
+#  file_url          :string
+#  message           :text
+#  status            :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  backup_routine_id :integer          not null
+#
+# Indexes
+#
+#  index_backup_logs_on_backup_routine_id  (backup_routine_id)
+#
+# Foreign Keys
+#
+#  backup_routine_id  (backup_routine_id => backup_routines.id)
+#
+class BackupLog < ApplicationRecord
+  belongs_to :backup_routine
+
+  belongs_to :backup_routine
+
+  enum :status, {
+    success: "success",
+    failure: "failure"
+  }
+
+  validates :status, presence: true
+end

--- a/app/models/backup_log.rb
+++ b/app/models/backup_log.rb
@@ -20,7 +20,6 @@
 #
 class BackupLog < ApplicationRecord
   belongs_to :backup_routine
-
   belongs_to :backup_routine
 
   enum :status, {

--- a/app/models/backup_log.rb
+++ b/app/models/backup_log.rb
@@ -20,7 +20,6 @@
 #
 class BackupLog < ApplicationRecord
   belongs_to :backup_routine
-  belongs_to :backup_routine
 
   enum :status, {
     success: "success",

--- a/app/models/backup_routine.rb
+++ b/app/models/backup_routine.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: backup_routines
+#
+#  id                     :integer          not null, primary key
+#  frequency              :string
+#  name                   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  database_connection_id :integer          not null
+#  destination_id         :integer          not null
+#
+# Indexes
+#
+#  index_backup_routines_on_database_connection_id  (database_connection_id)
+#  index_backup_routines_on_destination_id          (destination_id)
+#
+# Foreign Keys
+#
+#  database_connection_id  (database_connection_id => database_connections.id)
+#  destination_id          (destination_id => destinations.id)
+#
+class BackupRoutine < ApplicationRecord
+  belongs_to :database_connection
+  belongs_to :destination
+
+  has_many :backup_logs, dependent: :destroy
+
+  enum :frequency, {
+    daily: "daily",
+    hourly: "hourly",
+    weekly: "weekly"
+  }
+
+  validates :name, :frequency, presence: true
+end

--- a/app/models/database_connection.rb
+++ b/app/models/database_connection.rb
@@ -14,4 +14,11 @@
 #  updated_at    :datetime         not null
 #
 class DatabaseConnection < ApplicationRecord
+  has_many :backup_routines, dependent: :destroy
+
+  validates :name, :host, :port, :username, :password, :database_name, :sslmode, presence: true
+
+  def connection_url
+    "postgres://#{username}:#{password}@#{host}:#{port}/#{database_name}?sslmode=#{sslmode}"
+  end
 end

--- a/app/models/database_connection.rb
+++ b/app/models/database_connection.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: database_connections
+#
+#  id            :integer          not null, primary key
+#  database_name :string
+#  host          :string
+#  name          :string
+#  password      :string
+#  port          :integer
+#  sslmode       :string
+#  username      :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+class DatabaseConnection < ApplicationRecord
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -15,4 +15,9 @@
 #  project_id        :string
 #
 class Destination < ApplicationRecord
+  enum :provider, { s3: "s3", google_drive: "google_drive" }
+
+  has_many :backup_routines, dependent: :nullify
+
+  validates :name, :provider, :bucket, presence: true
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: destinations
+#
+#  id                :integer          not null, primary key
+#  bucket            :string
+#  credentials_path  :string
+#  name              :string
+#  provider          :string
+#  region            :string
+#  secret_access_key :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  access_key_id     :string
+#  project_id        :string
+#
+class Destination < ApplicationRecord
+end

--- a/db/migrate/20250605015412_create_database_connections.rb
+++ b/db/migrate/20250605015412_create_database_connections.rb
@@ -1,0 +1,15 @@
+class CreateDatabaseConnections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :database_connections do |t|
+      t.string :name
+      t.string :host
+      t.integer :port
+      t.string :username
+      t.string :password
+      t.string :database_name
+      t.string :sslmode
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250605020603_create_destinations.rb
+++ b/db/migrate/20250605020603_create_destinations.rb
@@ -1,0 +1,16 @@
+class CreateDestinations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :destinations do |t|
+      t.string :name
+      t.string :provider
+      t.string :bucket
+      t.string :region
+      t.string :access_key_id
+      t.string :secret_access_key
+      t.string :project_id
+      t.string :credentials_path
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250605022132_create_backup_routines.rb
+++ b/db/migrate/20250605022132_create_backup_routines.rb
@@ -1,0 +1,12 @@
+class CreateBackupRoutines < ActiveRecord::Migration[8.0]
+  def change
+    create_table :backup_routines do |t|
+      t.string :name
+      t.string :frequency
+      t.references :database_connection, null: false, foreign_key: true
+      t.references :destination, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250605022243_create_backup_logs.rb
+++ b/db/migrate/20250605022243_create_backup_logs.rb
@@ -1,0 +1,12 @@
+class CreateBackupLogs < ActiveRecord::Migration[8.0]
+  def change
+    create_table :backup_logs do |t|
+      t.references :backup_routine, null: false, foreign_key: true
+      t.string :status
+      t.text :message
+      t.string :file_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_011745) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_015412) do
+  create_table "database_connections", force: :cascade do |t|
+    t.string "name"
+    t.string "host"
+    t.integer "port"
+    t.string "username"
+    t.string "password"
+    t.string "database_name"
+    t.string "sslmode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "motor_alert_locks", force: :cascade do |t|
     t.integer "alert_id", null: false
     t.string "lock_timestamp", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_015412) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_020603) do
   create_table "database_connections", force: :cascade do |t|
     t.string "name"
     t.string "host"
@@ -19,6 +19,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_015412) do
     t.string "password"
     t.string "database_name"
     t.string "sslmode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "destinations", force: :cascade do |t|
+    t.string "name"
+    t.string "provider"
+    t.string "bucket"
+    t.string "region"
+    t.string "access_key_id"
+    t.string "secret_access_key"
+    t.string "project_id"
+    t.string "credentials_path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_022132) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_022243) do
+  create_table "backup_logs", force: :cascade do |t|
+    t.integer "backup_routine_id", null: false
+    t.string "status"
+    t.text "message"
+    t.string "file_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["backup_routine_id"], name: "index_backup_logs_on_backup_routine_id"
+  end
+
   create_table "backup_routines", force: :cascade do |t|
     t.string "name"
     t.string "frequency"
@@ -240,6 +250,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_022132) do
     t.index ["name"], name: "motor_tags_name_unique_index", unique: true
   end
 
+  add_foreign_key "backup_logs", "backup_routines"
   add_foreign_key "backup_routines", "database_connections"
   add_foreign_key "backup_routines", "destinations"
   add_foreign_key "motor_alert_locks", "motor_alerts", column: "alert_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_020603) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_022132) do
+  create_table "backup_routines", force: :cascade do |t|
+    t.string "name"
+    t.string "frequency"
+    t.integer "database_connection_id", null: false
+    t.integer "destination_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["database_connection_id"], name: "index_backup_routines_on_database_connection_id"
+    t.index ["destination_id"], name: "index_backup_routines_on_destination_id"
+  end
+
   create_table "database_connections", force: :cascade do |t|
     t.string "name"
     t.string "host"
@@ -229,6 +240,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_020603) do
     t.index ["name"], name: "motor_tags_name_unique_index", unique: true
   end
 
+  add_foreign_key "backup_routines", "database_connections"
+  add_foreign_key "backup_routines", "destinations"
   add_foreign_key "motor_alert_locks", "motor_alerts", column: "alert_id"
   add_foreign_key "motor_alerts", "motor_queries", column: "query_id"
   add_foreign_key "motor_note_tag_tags", "motor_note_tags", column: "tag_id"

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/test/fixtures/backup_logs.yml
+++ b/test/fixtures/backup_logs.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  backup_routine: one
+  status: MyString
+  message: MyText
+  file_url: MyString
+
+two:
+  backup_routine: two
+  status: MyString
+  message: MyText
+  file_url: MyString

--- a/test/fixtures/backup_routines.yml
+++ b/test/fixtures/backup_routines.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  frequency: MyString
+  database_connection: one
+  destination: one
+
+two:
+  name: MyString
+  frequency: MyString
+  database_connection: two
+  destination: two

--- a/test/fixtures/database_connections.yml
+++ b/test/fixtures/database_connections.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  host: MyString
+  port: 1
+  username: MyString
+  password: MyString
+  database_name: MyString
+  sslmode: MyString
+
+two:
+  name: MyString
+  host: MyString
+  port: 1
+  username: MyString
+  password: MyString
+  database_name: MyString
+  sslmode: MyString

--- a/test/fixtures/destinations.yml
+++ b/test/fixtures/destinations.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  provider: MyString
+  bucket: MyString
+  region: MyString
+  access_key_id: MyString
+  secret_access_key: MyString
+  project_id: MyString
+  credentials_path: MyString
+
+two:
+  name: MyString
+  provider: MyString
+  bucket: MyString
+  region: MyString
+  access_key_id: MyString
+  secret_access_key: MyString
+  project_id: MyString
+  credentials_path: MyString

--- a/test/models/backup_log_test.rb
+++ b/test/models/backup_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BackupLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/backup_routine_test.rb
+++ b/test/models/backup_routine_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BackupRoutineTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/database_connection_test.rb
+++ b/test/models/database_connection_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DatabaseConnectionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/destination_test.rb
+++ b/test/models/destination_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DestinationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request introduces a backup management system, including models, migrations, and schema updates, as well as the integration of the `annotaterb` gem for schema annotations. The most important changes are grouped into the following themes:

### Backup Management System

* Added models for `BackupLog`, `BackupRoutine`, `DatabaseConnection`, and `Destination`, including relationships, validations, and enumerations. These models form the core of the backup management system. (`app/models/backup_log.rb` [[1]](diffhunk://#diff-929b43654e500803dda1e35db0cb1c07a848e895b5e06e5fb925832a98d10c7cR1-R30) `app/models/backup_routine.rb` [[2]](diffhunk://#diff-f5c83cd341d6b9bd8c0524d81ed94b447b0bcdd3f6ca5c2f0dc41c7a1dced4bcR1-R36) `app/models/database_connection.rb` [[3]](diffhunk://#diff-93be541bb6bdb7392014e87b4d09e633c07e357eb68606fc842e8195232df8f3R1-R24) `app/models/destination.rb` [[4]](diffhunk://#diff-3bf0a33282d56ab837eac8a074fdeb35843c4ca2265abf5d7f8e9b92779c8fbeR1-R23)
* Created corresponding database migrations for the new models, defining their schema and relationships. (`db/migrate/20250605015412_create_database_connections.rb` [[1]](diffhunk://#diff-4698e8d2ad13ed0ec89983038f58caf83b06dcf1d6469260c35cef15b7d6217dR1-R15) `db/migrate/20250605020603_create_destinations.rb` [[2]](diffhunk://#diff-b302af340ada28019f146b7cc6302b6b84aae6715d7525c67b74790faa0c007aR1-R16) `db/migrate/20250605022132_create_backup_routines.rb` [[3]](diffhunk://#diff-0196d6276b61d6c67514e2fe161506256659d0040a738aec6e0171b1c41f8a97R1-R12) `db/migrate/20250605022243_create_backup_logs.rb` [[4]](diffhunk://#diff-0d2c6a0e8aceab95e178d303028c8328f41cc0f22e46c7a4de37ca71afe492deR1-R12)
* Updated `db/schema.rb` to reflect the new tables and foreign key constraints. (`db/schema.rb` [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R59) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R253-R255)

### Schema Annotation

* Integrated the `annotaterb` gem by adding it to the `Gemfile`, configuring it in `.annotaterb.yml`, and including a rake task in `lib/tasks/annotate_rb.rake`. This enables automatic schema annotation for models. (`Gemfile` [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR24) `.annotaterb.yml` [[2]](diffhunk://#diff-441821561d2197e89d270a9a32d54a2f5a9d0a3e0215010b24d50e01c308d4a6R1-R61) `lib/tasks/annotate_rb.rake` [[3]](diffhunk://#diff-578cdfc7ad56637e42472ea891ea286dff8803d9a1750afdbfeafec164d9b8b2R1-R8)
* Annotated the schema information in the newly added models for better documentation. (`app/models/backup_log.rb` [[1]](diffhunk://#diff-929b43654e500803dda1e35db0cb1c07a848e895b5e06e5fb925832a98d10c7cR1-R30) `app/models/backup_routine.rb` [[2]](diffhunk://#diff-f5c83cd341d6b9bd8c0524d81ed94b447b0bcdd3f6ca5c2f0dc41c7a1dced4bcR1-R36) `app/models/database_connection.rb` [[3]](diffhunk://#diff-93be541bb6bdb7392014e87b4d09e633c07e357eb68606fc842e8195232df8f3R1-R24) `app/models/destination.rb` [[4]](diffhunk://#diff-3bf0a33282d56ab837eac8a074fdeb35843c4ca2265abf5d7f8e9b92779c8fbeR1-R23)

### Test Fixtures and Stubs

* Added fixtures for the new models to support testing. (`test/fixtures/backup_logs.yml` [[1]](diffhunk://#diff-f63c7381bf563f132b26260f2c69f706a31b6a5c9ef38e8be8004c0ddba6ac82R1-R13) `test/fixtures/backup_routines.yml` [[2]](diffhunk://#diff-99272a66f734df679e009aead3b0a4da31e0d9d7632dc04843d04ccf828d7b5aR1-R13) `test/fixtures/database_connections.yml` [[3]](diffhunk://#diff-50e4d097010ee541d66ef0b692a72fe627b512e86565ea62e843c48ed138e9e1R1-R19) `test/fixtures/destinations.yml` [[4]](diffhunk://#diff-d927b3fa825e4533e13c217cff004d01767fa3aafb5e5c20f3885bab725efdcbR1-R21)
* Created placeholder test files for the models, which can be expanded with actual test cases. (`test/models/backup_log_test.rb` [[1]](diffhunk://#diff-e28ac057a94732a93951a3203f5782ebf8463eedefa36a5d3e69de732b288329R1-R7) `test/models/backup_routine_test.rb` [[2]](diffhunk://#diff-c1609c3156460767254618a2be42498887d45a83e7438ca97d0c063f620c38ccR1-R7) `test/models/database_connection_test.rb` [[3]](diffhunk://#diff-6e22069a57e3be8d912b04281852eb1bfe311285d450ffbcd907cdeafce852baR1-R7) `test/models/destination_test.rb` [[4]](diffhunk://#diff-2eb548c081f570c098b2b86ce49188b1f4f11c5d1483381734fed97c742d56caR1-R7)