### PR TITLE
create-backup-run-model

### DIFF
--- a/app/models/backup_log.rb
+++ b/app/models/backup_log.rb
@@ -2,24 +2,23 @@
 #
 # Table name: backup_logs
 #
-#  id                :integer          not null, primary key
-#  file_url          :string
-#  message           :text
-#  status            :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  backup_routine_id :integer          not null
+#  id            :integer          not null, primary key
+#  message       :json
+#  status        :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  backup_run_id :integer          not null
 #
 # Indexes
 #
-#  index_backup_logs_on_backup_routine_id  (backup_routine_id)
+#  index_backup_logs_on_backup_run_id  (backup_run_id)
 #
 # Foreign Keys
 #
-#  backup_routine_id  (backup_routine_id => backup_routines.id)
+#  backup_run_id  (backup_run_id => backup_runs.id)
 #
 class BackupLog < ApplicationRecord
-  belongs_to :backup_routine
+  belongs_to :backup_run
 
   enum :status, {
     success: "success",

--- a/app/models/backup_routine.rb
+++ b/app/models/backup_routine.rb
@@ -24,7 +24,7 @@ class BackupRoutine < ApplicationRecord
   belongs_to :database_connection
   belongs_to :destination
 
-  has_many :backup_logs, dependent: :destroy
+  has_many :backup_runs, dependent: :destroy
 
   enum :frequency, {
     daily: "daily",

--- a/app/models/backup_run.rb
+++ b/app/models/backup_run.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: backup_runs
+#
+#  id                :integer          not null, primary key
+#  file_url          :string
+#  finished_at       :datetime
+#  started_at        :datetime
+#  status            :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  backup_routine_id :integer          not null
+#
+# Indexes
+#
+#  index_backup_runs_on_backup_routine_id  (backup_routine_id)
+#
+# Foreign Keys
+#
+#  backup_routine_id  (backup_routine_id => backup_routines.id)
+#
+class BackupRun < ApplicationRecord
+  belongs_to :backup_routine
+
+  has_many :backup_logs, dependent: :destroy
+end

--- a/config/motor.yml
+++ b/config/motor.yml
@@ -1,6 +1,6 @@
 ---
 engine_version: 0.4.36
-file_version: 2025-06-05 12:32:08.056332000 -03:00
+file_version: 2025-06-05 12:45:54.240004000 -03:00
 resources:
 - name: backup_log
   preferences:
@@ -9,7 +9,8 @@ resources:
       name: not_success
     - visible: false
       name: not_failure
-  updated_at: 2025-06-05 12:31:37.435406000 +00:00
+    visible: false
+  updated_at: 2025-06-05 12:45:54.240004000 +00:00
 - name: backup_routine
   preferences:
     scopes:

--- a/db/migrate/20250605123650_create_backup_runs.rb
+++ b/db/migrate/20250605123650_create_backup_runs.rb
@@ -1,0 +1,18 @@
+class CreateBackupRuns < ActiveRecord::Migration[8.0]
+  def change
+    remove_columns :backup_logs, :backup_routine_id, :message, :file_url
+
+    create_table :backup_runs do |t|
+      t.belongs_to :backup_routine, null: false, foreign_key: true
+      t.string :status
+      t.string :file_url
+      t.datetime :started_at
+      t.datetime :finished_at
+
+      t.timestamps
+    end
+
+    add_reference :backup_logs, :backup_run, null: false, foreign_key: true
+    add_column :backup_logs, :message, :json, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_022243) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_05_123650) do
   create_table "backup_logs", force: :cascade do |t|
-    t.integer "backup_routine_id", null: false
     t.string "status"
-    t.text "message"
-    t.string "file_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["backup_routine_id"], name: "index_backup_logs_on_backup_routine_id"
+    t.integer "backup_run_id", null: false
+    t.json "message"
+    t.index ["backup_run_id"], name: "index_backup_logs_on_backup_run_id"
   end
 
   create_table "backup_routines", force: :cascade do |t|
@@ -30,6 +29,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_022243) do
     t.datetime "updated_at", null: false
     t.index ["database_connection_id"], name: "index_backup_routines_on_database_connection_id"
     t.index ["destination_id"], name: "index_backup_routines_on_destination_id"
+  end
+
+  create_table "backup_runs", force: :cascade do |t|
+    t.integer "backup_routine_id", null: false
+    t.string "status"
+    t.string "file_url"
+    t.datetime "started_at"
+    t.datetime "finished_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["backup_routine_id"], name: "index_backup_runs_on_backup_routine_id"
   end
 
   create_table "database_connections", force: :cascade do |t|
@@ -250,9 +260,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_022243) do
     t.index ["name"], name: "motor_tags_name_unique_index", unique: true
   end
 
-  add_foreign_key "backup_logs", "backup_routines"
+  add_foreign_key "backup_logs", "backup_runs"
   add_foreign_key "backup_routines", "database_connections"
   add_foreign_key "backup_routines", "destinations"
+  add_foreign_key "backup_runs", "backup_routines"
   add_foreign_key "motor_alert_locks", "motor_alerts", column: "alert_id"
   add_foreign_key "motor_alerts", "motor_queries", column: "query_id"
   add_foreign_key "motor_note_tag_tags", "motor_note_tags", column: "tag_id"

--- a/test/fixtures/backup_runs.yml
+++ b/test/fixtures/backup_runs.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  backup_routine: one
+  status: MyString
+  started_at: 2025-06-05 09:36:50
+  finished_at: 2025-06-05 09:36:50
+
+two:
+  backup_routine: two
+  status: MyString
+  started_at: 2025-06-05 09:36:50
+  finished_at: 2025-06-05 09:36:50

--- a/test/models/backup_run_test.rb
+++ b/test/models/backup_run_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BackupRunTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request introduces a significant refactor to the backup system by replacing the `BackupRoutine` and `BackupLog` relationship with a new `BackupRun` model. This change aims to better represent the relationship between backup routines and their individual executions. Additionally, updates were made to the database schema, configuration files, and test fixtures to support this new model.

### Model and Schema Changes:
* Introduced a new `BackupRun` model to represent individual executions of a backup routine. It includes fields such as `status`, `file_url`, `started_at`, and `finished_at` (`app/models/backup_run.rb`, `db/migrate/20250605123650_create_backup_runs.rb`, [[1]](diffhunk://#diff-59745ba539946e6981667d98f693956c8870b3a9bc03894c4557993e39d1245cR1-R26) [[2]](diffhunk://#diff-d1c3b6ed9688007565f3a67540f1888461bc117bb108b706c4e72b3a7b577720R1-R18).
* Updated `BackupLog` to reference `BackupRun` instead of `BackupRoutine`, and changed the `message` field to JSON format for better structure (`app/models/backup_log.rb`, `db/migrate/20250605123650_create_backup_runs.rb`, [[1]](diffhunk://#diff-929b43654e500803dda1e35db0cb1c07a848e895b5e06e5fb925832a98d10c7cL6-R21) [[2]](diffhunk://#diff-d1c3b6ed9688007565f3a67540f1888461bc117bb108b706c4e72b3a7b577720R1-R18).
* Modified `BackupRoutine` to establish a `has_many` relationship with `BackupRun` instead of `BackupLog` (`app/models/backup_routine.rb`, [app/models/backup_routine.rbL27-R27](diffhunk://#diff-f5c83cd341d6b9bd8c0524d81ed94b447b0bcdd3f6ca5c2f0dc41c7a1dced4bcL27-R27)).

### Database Migration and Schema Updates:
* Created a migration to add the `backup_runs` table, update foreign keys in `backup_logs`, and remove deprecated columns (`db/migrate/20250605123650_create_backup_runs.rb`, [db/migrate/20250605123650_create_backup_runs.rbR1-R18](diffhunk://#diff-d1c3b6ed9688007565f3a67540f1888461bc117bb108b706c4e72b3a7b577720R1-R18)).
* Updated the schema to reflect the new `backup_runs` table and the updated relationships (`db/schema.rb`, [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R20) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R34-R44) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L253-R266).

### Configuration and Tests:
* Updated `config/motor.yml` to adapt to the new model structure (`config/motor.yml`, [[1]](diffhunk://#diff-4728215822e3c21d1deb205810a7434e3a5ed8a8f7693ecd44c0e21f3a104982L3-R3) [[2]](diffhunk://#diff-4728215822e3c21d1deb205810a7434e3a5ed8a8f7693ecd44c0e21f3a104982L12-R13).
* Added test fixtures and a placeholder test file for the `BackupRun` model (`test/fixtures/backup_runs.yml`, `test/models/backup_run_test.rb`, [[1]](diffhunk://#diff-a9eb8d4c923153bc2e9cc2f4e29ae6bb22d433710786736731bd9da75a7b6a2bR1-R13) [[2]](diffhunk://#diff-ee53eba6c3630bea767eb86c0ddfcd5d7155390722177398b2314f9a01d65e6bR1-R7).