### PR TITLE
Readme tweaks and sslmode fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Follow these steps to get VitaPG up and running on your local machine for develo
 1.  **Clone the repository:**
     ```bash
     git clone https://github.com/your-username/vitapg.git
-    cd vitapg
+    cd VitaPG
     ```
     
 2.  **Install dependencies:**
@@ -80,7 +80,7 @@ Follow these steps to get VitaPG up and running on your local machine for develo
 Once VitaPG is running, you can manage your backup operations through the Motor-Admin interface:
 
 1.  **Access the Admin Interface:**
-    Open your web browser and navigate to `http://localhost:3000/admin` (or your production URL followed by `/admin`).
+    Open your web browser and navigate to `http://localhost:3000/admin` (or your production URL followed by `/admin`). Username = `admin`, Password = `/admin`.
 
 2.  **Configure Database Connections:**
     - Go to the "Database Connections" section.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Follow these steps to get VitaPG up and running on your local machine for develo
 Once VitaPG is running, you can manage your backup operations through the Motor-Admin interface:
 
 1.  **Access the Admin Interface:**
-    Open your web browser and navigate to `http://localhost:3000/admin` (or your production URL followed by `/admin`). Username = `admin`, Password = `/admin`.
+    Open your web browser and navigate to `http://localhost:3000/admin` (or your production URL followed by `/admin`). The default credentials are Username = `admin` and Password = `admin`.
 
 2.  **Configure Database Connections:**
     - Go to the "Database Connections" section.

--- a/app/models/database_connection.rb
+++ b/app/models/database_connection.rb
@@ -17,6 +17,8 @@ class DatabaseConnection < ApplicationRecord
 
   validates :name, :host, :port, :username, :password, :database_name, :sslmode, presence: true
 
+  enum :sslmode, { disable: "disable", allow: "allow" , prefer: "prefer", require: "require", verify_ca: "verify-ca", verify_full: "verify-full" }, default: :disable
+
   def connection_url
     "postgres://#{username}:#{password}@#{host}:#{port}/#{database_name}?sslmode=#{sslmode}"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,6 +56,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_145208) do
     t.string "database_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sslmode"
   end
 
   create_table "destinations", force: :cascade do |t|


### PR DESCRIPTION
My first, very basic PR

Updated the ReadMe based on some improvements that came up for me in the install.

Ran into an error with creating a database_connection b/c there was a missing sslmode field in Motor-Admin, so I added that to the table in the schema and made it an enum based on the options here: https://www.postgresql.org/docs/current/libpq-ssl.html